### PR TITLE
update gpg key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,8 +64,12 @@ ARG INSTALL_PACKAGE=desktop
 
 RUN apt-get update -q && \
     apt-get install -y curl gnupg2 lsb-release && \
+    # 古いキーを削除
+    apt-key del F42ED6FBAB17C654 || true && \
+    # 新しいキーを追加
     curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg && \
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" \
+    | tee /etc/apt/sources.list.d/ros2.list > /dev/null && \
     apt-get update -q && \
     apt-get install -y ros-${ROS_DISTRO}-${INSTALL_PACKAGE} \
     python3-argcomplete \


### PR DESCRIPTION
## PR Type
<!--
Please select the type of changes you're introducing to the codebase:
-->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Overview
gpg鍵の更新

## Detail
ROS 2 の公式リポジトリの GPG鍵（署名鍵）が期限切れになったため、更新しました。

## Test
- [x] I have tested this change 

## Attention
build時にエラーは出ませんでした。コンテナ作成できるかは試していないため余裕があればしておきます。